### PR TITLE
[jjo] more os/ deploy fixes

### DIFF
--- a/k/Makefile
+++ b/k/Makefile
@@ -57,7 +57,7 @@ helm: certmanager
 	$(HELM) init
 	$(HELM) ls --all
 
-nginx-ingress: helm
+nginx-ingress:
 	$(KBCTL) apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml
 	$(KBCTL) apply -f $(K8SCONF)cloud-generic.yaml
 
@@ -71,5 +71,5 @@ openebs:
 
 K8SCONF=configs/
 SHELL:= /bin/bash
-KBCTL=kubectl --insecure-skip-tls-verify --kubeconfig ./admin.conf
+KBCTL=kubectl --insecure-skip-tls-verify
 HELM=KUBECONFIG=./admin.conf helm

--- a/k/configs/metallb-ip-address.yaml
+++ b/k/configs/metallb-ip-address.yaml
@@ -9,4 +9,4 @@ data:
     - name: default
       protocol: layer2
       addresses:
-      - 190.15.222.144-190.15.222.151
+      - 172.16.16.208-172.16.16.223

--- a/os/Makefile
+++ b/os/Makefile
@@ -4,11 +4,18 @@ SETUP_VENV=pyvenv .venv
 USE_VENV=source .venv/bin/activate
 TEST_VENV=test -f .venv/bin/activate
 
+# TODO(jjo): get from chart vars, should be svc.umcloud.local
+OS_DOMAIN=openstack.svc.cluster.local
+KEYSTONE_FQDN=keystone.$(OS_DOMAIN)
+KEYSTONE_FQDN_HOSTS=$(KEYSTONE_FQDN) $(shell echo {keystone,cinder,glance,neutron,nova,placement,heat}{,-api}.$(OS_DOMAIN))
+
 # DEPLOY_TYPE can be: developer/common (dev) or multinode (prod)
-#DEPLOY_TYPE=multinode
-DEPLOY_TYPE=developer/common
+DEPLOY_TYPE=multinode
+#DEPLOY_TYPE=developer/common
 # TODO(jjo): adapt ceph stuff to Rook
-DEPLOY_GREP='mariadb|rabbitmq|memcached|keystone|glance|cinder|openvswitch|libvirt|compute-kit|heat|ceph-radosgateway'
+# NOTE: compute-kit includes: nova, neutron
+# F_ck... it REALLY wants its own ingress (!): installs in kube-system *and* openstack NS ("ingress" Pods)
+DEPLOY_GREP='mariadb|rabbitmq|ingress|memcached|keystone|glance|cinder|openvswitch|libvirt|compute-kit|heat|ceph-radosgateway'
 # @navarrow won't let me go without horizon ...
 DEPLOY_SCRIPTS_PATT=$(REPO_ROOT)/openstack-helm/tools/deployment/$(DEPLOY_TYPE)/[0-9]*
 DEPLOY_SCRIPTS_EXTRA=$(REPO_ROOT)/openstack-helm/tools/deployment/developer/common/100-horizon.sh
@@ -61,8 +68,17 @@ $(OPENSTACK_CLOUDS): $(OSH_PASSWORDS_ENV)
 # then all nodes for nova (and needed openvswitch)
 label-kube-nodes:
 	kubectl label nodes openstack-control-plane=enabled -l node-role.kubernetes.io/master --overwrite
-	kubectl label nodes openstack-helm-node-class=primary --all --overwrite
+	kubectl label nodes openstack-helm-node-class=primary -l node-role.kubernetes.io/master --overwrite
+	kubectl label nodes openstack-compute-node=enabled --all --overwrite
 	kubectl label nodes openvswitch=enabled --all --overwrite
+
+hack-etc-hosts:
+	$(eval INGRESS_IP=$(shell kubectl get svc -n ingress-nginx ingress-nginx -ojsonpath='{.status.loadBalancer.ingress[0].ip}'))
+	@test $(INGRESS_IP) != ""
+	egrep $(KEYSTONE_FQDN) /etc/hosts && \
+		sudo sed -i.bak '/$(KEYSTONE_FQDN)/s/.*/$(INGRESS_IP) $(KEYSTONE_FQDN_HOSTS)/' /etc/hosts || \
+		{ echo $(INGRESS_IP) $(KEYSTONE_FQDN_HOSTS) | sudo tee -a /etc/hosts; }
+
 
 $(CHARTS_VALUES_YAML): configs/os-charts-values.tmpl.yaml $(OSH_PASSWORDS_ENV) Makefile
 	. $(OSH_PASSWORDS_ENV) && envsubst < $(<) > $(@)
@@ -73,10 +89,14 @@ $(OSH_PASSWORDS_ENV):
 # Do the actual deploy by running DEPLOY_SCRIPTS in sequence,
 # DEPLOY_SCRIPTS is filtered-in for only the components we want
 # to deploy
+# Need to void NETWORK_TUNNEL_DEV=<local_default_route_interface> to avoid using this *local*
+# iface on cluster nodes (wtf?)
 os-deploy:
 	@echo "Deploying for DEPLOY_TYPE=$(DEPLOY_TYPE) ..."
 	@cd $(REPO_ROOT)/openstack-helm && export OSH_EXTRA_HELM_ARGS=$(OSH_EXTRA_HELM_ARGS) && \
-		for i in $(DEPLOY_SCRIPTS); do (set -x; echo "=== $$i ==="; env PS4='=== ' $$i); done
+		for i in $(DEPLOY_SCRIPTS); do \
+		(echo "=== $$i ==="; sed -r -e '/tunnel:.*NETWORK_TUNNEL_DEV.*/s/tunnel:/tunnel_broken_disabled:/' $$i | env PS4='=== ' bash); \
+		done
 
 # Run 'helm template' instead on each chart, to peek
 # at the generated YAML output for the deploy
@@ -103,6 +123,7 @@ os-test-bad-passwords:
 	@echo 'Showing charts configured with secrets as "password"[sic]'
 	$(eval PASSWORD_B64=$(shell echo -n password|base64))
 	($(MAKE) os-template | egrep -v OS_AUTH_TYPE: | egrep -B5 '$(PASSWORD_B64)' >&2) 2>&1; [ $$? -ne 0 ]
+	($(MAKE) os-template | sed -rn 's/  .+_CONNECTION:.//p'|xargs -I@ sh -c 'echo @|base64 -d;echo' | egrep '$(PASSWORD_B64)' >&2); [ $$? -ne 0 ]
 	@echo PASS
 
 # Package all openstack-help-infra charts
@@ -131,7 +152,8 @@ package-osh-charts:
 # PVs will persist, also creds are not resetted so a new deploy
 # should work.
 os-destroy:
-	helm ls --namespace=openstack -q|xargs -r helm delete --purge
+	helm ls --namespace=openstack -q|xargs -tr helm delete --purge
+	kubectl delete job,pod,cm --namespace=openstack --all --grace-period=1
 
 # DANGER: this will completely destroy the openstack deploy,
 # including its PVs (deleting the NS) and the credentials

--- a/os/configs/os-charts-values.tmpl.yaml
+++ b/os/configs/os-charts-values.tmpl.yaml
@@ -27,6 +27,18 @@ endpoints:
         password: ${NOVA_DB_PASSWORD}
       heat:
         password: ${HEAT_DB_PASSWORD}
+  oslo_db_api:
+    auth:
+      admin:
+        password: ${OSH_MARIADB_ADMIN_PASSWORD}
+      nova:
+        password: ${NOVA_DB_PASSWORD}
+  oslo_db_cell0:
+    auth:
+      admin:
+        password: ${OSH_MARIADB_ADMIN_PASSWORD}
+      nova:
+        password: ${NOVA_DB_PASSWORD}
 # rabbitmq
   oslo_messaging:
     auth:
@@ -72,3 +84,8 @@ endpoints:
   oslo_cache:
     auth:
       memcache_secret_key: ${KEYSTONE_AUTHTOKEN_MEMCACHED_SECRET_KEY}
+# neutron
+# TODO(jjo): use makefile var, e.g. NEUTRON_BR_EX_IFACE=enp5s0
+conf:
+  auto_bridge_add:
+    br-ex: enp5s0

--- a/os/patches/openstack-helm/neutron-skip-bridge-mapping-iface-if-not-found.patch
+++ b/os/patches/openstack-helm/neutron-skip-bridge-mapping-iface-if-not-found.patch
@@ -1,0 +1,26 @@
+diff --git a/neutron/templates/bin/_neutron-linuxbridge-agent-init.sh.tpl b/neutron/templates/bin/_neutron-linuxbridge-agent-init.sh.tpl
+index 71a2b6b..849bc90 100644
+--- a/neutron/templates/bin/_neutron-linuxbridge-agent-init.sh.tpl
++++ b/neutron/templates/bin/_neutron-linuxbridge-agent-init.sh.tpl
+@@ -29,7 +29,7 @@ do
+   ip link add name $bridge type bridge
+   set -e
+   ip link set dev $bridge up
+-  if [ -n "$iface" ] && [ "$iface" != "null" ]
++  if [ -n "$iface" ] && [ "$iface" != "null" ] && ip link show ${iface} >/dev/null
+   then
+     ip link set dev $iface  master $bridge
+   fi
+diff --git a/neutron/templates/bin/_neutron-openvswitch-agent-init.sh.tpl b/neutron/templates/bin/_neutron-openvswitch-agent-init.sh.tpl
+index 4dfb0ff..19536bd 100644
+--- a/neutron/templates/bin/_neutron-openvswitch-agent-init.sh.tpl
++++ b/neutron/templates/bin/_neutron-openvswitch-agent-init.sh.tpl
+@@ -42,7 +42,7 @@ do
+   bridge=${bmap%:*}
+   iface=${bmap#*:}
+   ovs-vsctl --no-wait --may-exist add-br $bridge
+-  if [ -n "$iface" ] && [ "$iface" != "null" ]
++  if [ -n "$iface" ] && [ "$iface" != "null" ] && ip link show ${iface} >/dev/null
+   then
+     ovs-vsctl --no-wait --may-exist add-port $bridge $iface
+     ip link set dev $iface up


### PR DESCRIPTION
* Add @navarrow-um 's k/ fixes and customization for proper metallb CIDR
* Several fixes to move fwd more os/ components deploy-s:
 `keystone, cinder[*], glance[*], neutron, nova[*], placement, heat,
  ceph-radosgateway[*]`

`[*]` these components' Pods block on init dependencies from missing
ceph-etc client-side setup.