### PR TITLE
[jjo] fix nova-compute to use virt_type=kvm, add nodes

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -7,7 +7,7 @@ SHELL=/bin/bash
 # kubespray/contrib/inventory_builder/inventory.py will still start its node
 # naming from "1" (even if below was set e.g. to {101..110}).
 HOST_PREFIX=um-kros-
-NODES=$(HOST_PREFIX)01 $(HOST_PREFIX)02 $(HOST_PREFIX)03 $(HOST_PREFIX)05 $(HOST_PREFIX)07 $(HOST_PREFIX)08 $(HOST_PREFIX)09 $(HOST_PREFIX)10
+NODES=$(HOST_PREFIX)01 $(HOST_PREFIX)02 $(HOST_PREFIX)03 $(HOST_PREFIX)04 $(HOST_PREFIX)05 $(HOST_PREFIX)06 $(HOST_PREFIX)07 $(HOST_PREFIX)08 $(HOST_PREFIX)09 $(HOST_PREFIX)10
 MASTER=$(HOST_PREFIX)01
 
 NODES_IPS=$(shell bash -c 'printf "%s\n" $(NODES)|xargs -l1 host|sed "s/.*address //"|xargs')

--- a/k/Makefile
+++ b/k/Makefile
@@ -41,6 +41,10 @@ cluster:
 cluster-upgrade:
 	source .venv/bin/activate && cd $(REPO_DIR) && \
 		ansible-playbook -u ubuntu -b -i $(INVENTORY_DIR)/hosts.yaml upgrade-cluster.yml
+cluster-scale:
+	source .venv/bin/activate && cd $(REPO_DIR) && \
+		ansible-playbook -u ubuntu -b -i $(INVENTORY_DIR)/hosts.yaml scale.yml
+
 
 cluster-reset:
 	source .venv/bin/activate && cd $(REPO_DIR) && \

--- a/k/configs/inventory/cluster/hosts.yaml
+++ b/k/configs/inventory/cluster/hosts.yaml
@@ -12,10 +12,18 @@ all:
       ansible_host: 172.16.16.68
       ip: 172.16.16.68
       access_ip: 172.16.16.68
+    um-kros-04:
+      ansible_host: 172.16.16.70
+      ip: 172.16.16.70
+      access_ip: 172.16.16.70
     um-kros-05:
       ansible_host: 172.16.16.74
       ip: 172.16.16.74
       access_ip: 172.16.16.74
+    um-kros-06:
+      ansible_host: 172.16.16.71
+      ip: 172.16.16.71
+      access_ip: 172.16.16.71
     um-kros-07:
       ansible_host: 172.16.16.65
       ip: 172.16.16.65

--- a/os/Makefile
+++ b/os/Makefile
@@ -150,13 +150,16 @@ set_OSH_EXTRA_HELM_ARGS = \
 # to deploy
 # Need to void NETWORK_TUNNEL_DEV=<local_default_route_interface> to avoid using this *local*
 # iface on cluster nodes (wtf?)
+# On the fly fixes:
+# - disable the NETWORK_TUNNEL_DEV logic as this deployment host not necessarily equals nodes (wtf1!)
+# - virt_type=qemu by default, REALLY ?!, use =kvm for HW accel (wtf2!)
 
 os-deploy: creds ceph-client-conf
 	@echo "Deploying for DEPLOY_TYPE: $(DEPLOY_TYPE), DEPLOY_SCRIPTS: $(DEPLOY_SCRIPTS) ..."
 	@$(USE_VENV); cd $(REPO_ROOT)/openstack-helm && \
 		for deploy_script in $(DEPLOY_SCRIPTS); do \
 		$(set_OSH_EXTRA_HELM_ARGS) ;\
-		(echo "=== $$deploy_script ==="; sed -r -e '/tunnel:.*NETWORK_TUNNEL_DEV.*/s/tunnel:/tunnel_broken_disabled:/' $$deploy_script | env PS4='=== ' bash); \
+		(echo "=== $$deploy_script ==="; sed -r -e '/tunnel:.*NETWORK_TUNNEL_DEV.*/s/tunnel:/tunnel_broken_disabled:/' -e 's/virt_type=qemu/virt_type=kvm/' $$deploy_script | env PS4='=== ' bash); \
 		done
 
 # Run 'helm template' instead on each chart, to peek

--- a/os/configs/ceph-mon-openstack.env
+++ b/os/configs/ceph-mon-openstack.env
@@ -1,0 +1,3 @@
+export MON_0=172.16.16.66.xip.io
+export MON_1=172.16.16.73.xip.io
+export MON_2=172.16.16.68.xip.io

--- a/r/configs/cluster-kustom.yaml
+++ b/r/configs/cluster-kustom.yaml
@@ -33,7 +33,6 @@ spec:
     location: null
     nodes:
     - directories:
-      - path: /srv/ceph/ceph0
       - path: /srv/ceph/ceph1
       name: um-kros-01
     - directories:
@@ -47,7 +46,15 @@ spec:
     - directories:
       - path: /srv/ceph/ceph0
       - path: /srv/ceph/ceph1
+      name: um-kros-04
+    - directories:
+      - path: /srv/ceph/ceph0
+      - path: /srv/ceph/ceph1
       name: um-kros-05
+    - directories:
+      - path: /srv/ceph/ceph0
+      - path: /srv/ceph/ceph1
+      name: um-kros-06
     - directories:
       - path: /srv/ceph/ceph0
       - path: /srv/ceph/ceph1
@@ -60,9 +67,5 @@ spec:
       - path: /srv/ceph/ceph0
       - path: /srv/ceph/ceph1
       name: um-kros-09
-    - directories:
-      - path: /srv/ceph/ceph0
-      - path: /srv/ceph/ceph1
-      name: um-kros-10
     useAllDevices: false
     useAllNodes: false

--- a/r/configs/cluster-nodes.yaml
+++ b/r/configs/cluster-nodes.yaml
@@ -17,7 +17,15 @@ spec:
       directories:
       - path: /srv/ceph/ceph0
       - path: /srv/ceph/ceph1
+    - name: um-kros-04
+      directories:
+      - path: /srv/ceph/ceph0
+      - path: /srv/ceph/ceph1
     - name: um-kros-05
+      directories:
+      - path: /srv/ceph/ceph0
+      - path: /srv/ceph/ceph1
+    - name: um-kros-06
       directories:
       - path: /srv/ceph/ceph0
       - path: /srv/ceph/ceph1


### PR DESCRIPTION
* fix nova-compute to use `virt_type=kvm` instead of (wtf?) `=qemu`
  default from scripts
* add new nodes
* add `cluster-scale` target to `os/`